### PR TITLE
Add DjangoBook Resource to Django Learning Resources

### DIFF
--- a/topics/frameworks/django.md
+++ b/topics/frameworks/django.md
@@ -9,6 +9,8 @@ Angular in how features are included by default and its opinionated default sett
  * [VPS Configuration and Deployment](https://www.digitalocean.com/community/tutorials/how-to-set-up-django-with-postgres-nginx-and-gunicorn-on-ubuntu-20-04)
  * [A Complete BeginnersGuide to Django](https://simpleisbetterthancomplex.com/series/beginners-guide/1.11/)
   * [A Comprehensive introduction to Django web framework](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django)
+  * [Djangobook.com - A website of all available books on Django.](https://djangobook.com/)
+  * 
 
 ### Groups and Communities
  * [Django-Users Google Group](https://groups.google.com/forum/#!forum/django-users)


### PR DESCRIPTION
### Summary
This pull request adds the DjangoBook resource (https://djangobook.com/) to the learning resources section for Django frameworks. DjangoBook is a valuable website that compiles a comprehensive list of books available on Django, which can greatly benefit developers looking for educational materials on this framework.

### Changes
- Updated `Django.md` file to include a link to the DjangoBook website under the learning resources section for Django frameworks.

### Reason
Adding this resource aims to enhance the repository's learning resources by providing users with a centralized location for finding Django books. This addition will support both new learners and experienced developers in expanding their knowledge and skills in Django.

### Testing
No code changes were made, and this addition has been verified by checking the updated `Django.md` file to ensure the link is correctly formatted and functional.

### Related Issues
N/A

Please review and merge if everything looks good. Feedback is welcome!