### PR TITLE
Adds reference to wtfpython repository and removes redundant bullet point

### DIFF
--- a/topics/essentials.md
+++ b/topics/essentials.md
@@ -28,6 +28,9 @@ Comment by @Constuelo : "A large repository of open source books, administered b
 
 ## Code
 
+### [wtfpython: Exploring and understanding Python through surprising snippets](https://github.com/satwikkansal/wtfpython)
+Comment by @rjvitorino : "This project does a fantastic job of demystifying some of Python's unexpected outcomes, providing clear explanations and insights into Python's lesser-known features and nuances, a must-visit for any Python enthusiast looking to deepen their understanding of the language."
+
 ## Video
 
 ### [Dan Bader's Python Tutorials](https://www.youtube.com/channel/UCI0vQvr9aFn27yR6Ej6n5UA)

--- a/topics/frameworks/django.md
+++ b/topics/frameworks/django.md
@@ -10,7 +10,6 @@ Angular in how features are included by default and its opinionated default sett
  * [A Complete BeginnersGuide to Django](https://simpleisbetterthancomplex.com/series/beginners-guide/1.11/)
   * [A Comprehensive introduction to Django web framework](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django)
   * [Djangobook.com - A website of all available books on Django.](https://djangobook.com/)
-  * 
 
 ### Groups and Communities
  * [Django-Users Google Group](https://groups.google.com/forum/#!forum/django-users)


### PR DESCRIPTION
- Adds a new section under "Code" for the [wtfpython: Exploring and understanding Python through surprising snippets](https://github.com/satwikkansal/wtfpython) repository.
- Removes a redundant bullet point to improve clarity and organization.

These changes aim to enhance the resource list by introducing valuable content and removing unnecessary clutter.